### PR TITLE
Removed explicit setting of working directory.

### DIFF
--- a/src/main/groovy/com/infusionsoft/gradle/version/BuildVersionExtension.groovy
+++ b/src/main/groovy/com/infusionsoft/gradle/version/BuildVersionExtension.groovy
@@ -28,7 +28,6 @@ class BuildVersionExtension {
                 snapshotSuffix,
                 releaseTagIfNone)
         Repository repo = new FileRepositoryBuilder()
-                .setWorkTree(new File(projectPath))
                 .findGitDir(new File(projectPath))
                 .build()
         GitVersionResolver gitVersionResolver = new GitVersionResolver(repo, tagSomething)

--- a/src/test/groovy/com/infusionsoft/gradle/version/BuildVersionExtensionTest.groovy
+++ b/src/test/groovy/com/infusionsoft/gradle/version/BuildVersionExtensionTest.groovy
@@ -1,0 +1,21 @@
+package com.infusionsoft.gradle.version
+
+import static com.infusionsoft.gradle.version.TestData.getDefaultTagOptions
+import static org.testng.Assert.assertEquals
+
+import org.testng.annotations.Test
+
+public class BuildVersionExtensionTest extends TestNGRepositoryTestCase {
+  @Test
+  void testGetVersionSucceedsIfGitAboveCurrentDirectory() {
+    String expectedVersion = '0.0.1' + defaultTagOptions.releaseSuffix
+    final unit = new BuildVersionExtension()
+    unit.with {
+      projectPath = db.directory
+      isRelease = true
+    }
+    TestData.setupNewRepoWithSingleCommit(db)
+
+    assertEquals(unit.version, expectedVersion)
+  }
+}

--- a/src/test/groovy/com/infusionsoft/gradle/version/BuildVersionPluginTest.groovy
+++ b/src/test/groovy/com/infusionsoft/gradle/version/BuildVersionPluginTest.groovy
@@ -2,19 +2,11 @@ package com.infusionsoft.gradle.version
 
 import static org.junit.Assert.assertTrue
 
-import org.eclipse.jgit.junit.RepositoryTestCase
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
-class BuildVersionPluginTest extends RepositoryTestCase {
-    @BeforeMethod
-    public void setUp() throws Exception {
-        // superclass uses Junit @Before
-        super.setUp();
-    }
-
+class BuildVersionPluginTest extends TestNGRepositoryTestCase {
     @Test
     void testBuildVersionPluginAddsPushTagsTaskToProject() {
         Project project = ProjectBuilder.builder().build()

--- a/src/test/groovy/com/infusionsoft/gradle/version/GitVersionResolverTest.groovy
+++ b/src/test/groovy/com/infusionsoft/gradle/version/GitVersionResolverTest.groovy
@@ -1,21 +1,12 @@
 package com.infusionsoft.gradle.version
 
-import org.eclipse.jgit.junit.RepositoryTestCase
-import org.gradle.api.GradleScriptException
-
 import static com.infusionsoft.gradle.version.TestData.defaultTagOptions
 import static org.junit.Assert.assertEquals
 
-import org.testng.annotations.BeforeMethod
+import org.gradle.api.GradleScriptException
 import org.testng.annotations.Test
 
-class GitVersionResolverTest extends RepositoryTestCase {
-    @BeforeMethod
-    public void setUp() throws Exception {
-        // superclass uses Junit @Before
-        super.setUp();
-    }
-
+class GitVersionResolverTest extends TestNGRepositoryTestCase {
     @Test
     void testGetVersionNewRelease() {
         String previousVersion = '0.0.5' + defaultTagOptions.releaseSuffix

--- a/src/test/groovy/com/infusionsoft/gradle/version/TestData.groovy
+++ b/src/test/groovy/com/infusionsoft/gradle/version/TestData.groovy
@@ -52,6 +52,9 @@ class TestData {
 
     static Repository setupNewRepoWithSingleCommit(Repository repository) {
         Git git = new Git(repository)
+        File newFile = new File(repository.directory.parentFile.absoluteFile, 'newFile')
+        newFile.createNewFile()
+        git.add().addFilepattern('newFile').call()
         git.commit().setAuthor("Ratman", "ratman@infusionsoft.com").setMessage("I'm a single commit").call()
         repository
     }

--- a/src/test/groovy/com/infusionsoft/gradle/version/TestNGRepositoryTestCase.groovy
+++ b/src/test/groovy/com/infusionsoft/gradle/version/TestNGRepositoryTestCase.groovy
@@ -1,0 +1,12 @@
+package com.infusionsoft.gradle.version
+
+import org.eclipse.jgit.junit.RepositoryTestCase
+import org.testng.annotations.BeforeMethod
+
+abstract class TestNGRepositoryTestCase extends RepositoryTestCase {
+  @BeforeMethod
+  public void setUp() throws Exception {
+    // superclass uses Junit @Before
+    super.setUp();
+  }
+}


### PR DESCRIPTION
Allows JGit to set the working directory based on the location of the .git directory.

Added test to verify behavior when project path does not match .git parent directory.

Refactored existing RepositoryTestCase subclasses to remove common code.

@bryanstephens @swps @frossbeamish - PTAL